### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A mod inspired by the collar server, an improvement for the geometry dash pause 
 
 Special thanks:
 
--[Collar_2023_server] (https://discord.gg/9GX4Dkb)
+-[Collar_2023_server](https://discord.gg/9GX4Dkb)
 
 
--[Mat] (https://github.com/matcool)
+-[Mat](https://github.com/matcool)
 
 
--[Hjfod] (https://github.com/HJfod)
+-[Hjfod](https://github.com/HJfod)
 
 
--[Adaf] (https://github.com/adafcaefc)
+-[Adaf](https://github.com/adafcaefc)


### PR DESCRIPTION
i feel like the space was intentional, but why?