### PR TITLE
Fix mod ID

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -5,7 +5,7 @@
     "android": "2.205"
   },
   "version": "v1.6.8",
-  "id": "tpdea.betterpause-Better",
+  "id": "tpdea.betterpause-better",
   "name": "BetterPause",
   "developer": "Tpdea",
   "description": "A mod inspired by the collar server, an improvement for the geometry dash pause menu.",


### PR DESCRIPTION
Fix mod ID not following the regex: `[a-z0-9\-_]+\.[a-z0-9\-_]+`

In the future mod ID's must follow the regex `[a-z0-9\-_]+\.[a-z0-9\-_]+` or geode will reject them. The offending character was the capital B in the previous ID `tpdea.betterpause-Better`, this pull changes the capital B to a lowercase b. `tpdea.betterpause-better`